### PR TITLE
Fix premature destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ var reader = function (self, stream, toKey) {
   stream.on('readable', consume)
 
   return function (key, fn) {
-    if (ended) return self.destroy()
+    if (ended) return self.push(null)
     onmatch = fn
     target = key
     consume()

--- a/test.js
+++ b/test.js
@@ -143,3 +143,51 @@ tape('custom objects', function (t) {
     t.end()
   })
 })
+
+tape('primary stream ends early without pending match', function (t) {
+  var a = new Readable({objectMode: true})
+  var b = new Readable({objectMode: true})
+  a._read = b._read = function () {}
+
+  var intersection = intersect(a, b)
+  var acc = []
+
+  intersection.on('end', function () {
+    t.deepEqual(acc, [{key: 1}])
+    t.end()
+  })
+
+  intersection.on('data', acc.push.bind(acc))
+
+  a.push({key: 1})
+  b.push({key: 1})
+  a.push(null)
+
+  setImmediate(function () {
+    b.push(null)
+  })
+})
+
+tape('primary stream ends early with pending match', function (t) {
+  var a = new Readable({objectMode: true})
+  var b = new Readable({objectMode: true})
+  a._read = b._read = function () {}
+
+  var intersection = intersect(a, b)
+  var acc = []
+
+  intersection.on('end', function () {
+    t.deepEqual(acc, [{key: 1}])
+    t.end()
+  })
+
+  intersection.on('data', acc.push.bind(acc))
+
+  a.push({key: 1})
+  a.push(null)
+
+  setImmediate(function () {
+    b.push({key: 1})
+    b.push(null)
+  })
+})


### PR DESCRIPTION
If the primary stream ends before the second, and no data has yet been consumed from the second stream, `sorted-intersect-stream` will destroy itself prematurely.

I've added two tests to show this, the first test succeeds, the second test fails. I have a possible fix (not sure if it's the best way and it might have side-effects), but I'm hoping travis will start in a minute and show the failure. Afterwards I'll add a commit with the fix.
